### PR TITLE
Change default precision for decimal

### DIFF
--- a/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/io/confluent/connect/avro/AvroData.java
@@ -245,7 +245,7 @@ public class AvroData {
   static final String AVRO_LOGICAL_DECIMAL_SCALE_PROP = "scale";
   static final String AVRO_LOGICAL_DECIMAL_PRECISION_PROP = "precision";
   static final String CONNECT_AVRO_DECIMAL_PRECISION_PROP = "connect.decimal.precision";
-  static final Integer CONNECT_AVRO_DECIMAL_PRECISION_DEFAULT = 64;
+  static final Integer CONNECT_AVRO_DECIMAL_PRECISION_DEFAULT = 38;
 
   private static final HashMap<String, LogicalTypeConverter> TO_AVRO_LOGICAL_CONVERTERS
       = new HashMap<>();


### PR DESCRIPTION
https://github.com/confluentinc/kafka-connect-hdfs/issues/279

We can't use 64 as precision for decimal because is not supported by Hive